### PR TITLE
Match data types

### DIFF
--- a/src/AutoForm.php
+++ b/src/AutoForm.php
@@ -74,7 +74,8 @@ class AutoForm
 			case 'datetime':
 			    $type = 'date';
 			    break;
-			case 'checkbox':
+			case 'bool':
+			    $type = 'checkbox';
 			    if ($val) $params [] = 'checked';
 			    break;
 

--- a/src/dbSchema.php
+++ b/src/dbSchema.php
@@ -66,8 +66,6 @@ class DbSchema
 			case 'json':
 				return ' json DEFAULT NULL';
 				break;
-			case 'checkbox':
-			    return ' tinyint DEFAULT NULL';
 			case 'string':
 				if (isset ($field ['lenght']))
 				{


### PR DESCRIPTION
The boolean type is a synonym for TINYINT(1).
It can be unified in "src/dbSchema.php" and in the "src/AutoForm.php".